### PR TITLE
feat: add per-call elapsed time to ClaudeCodeLM log lines

### DIFF
--- a/plumb/programs/claude_code_lm.py
+++ b/plumb/programs/claude_code_lm.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
+import time
 from types import SimpleNamespace
 from typing import Any
 
@@ -62,6 +64,8 @@ def _call_claude(prompt: str, model: str | None = None, timeout: int = 300) -> s
         )
     }
 
+    print(f"[ClaudeCodeLM] Calling claude -p --model {model or 'default'} ({len(prompt)} chars)...", file=sys.stderr)
+    start = time.monotonic()
     result = subprocess.run(
         cmd,
         input=prompt,
@@ -70,10 +74,12 @@ def _call_claude(prompt: str, model: str | None = None, timeout: int = 300) -> s
         env=env,
         timeout=timeout,
     )
+    elapsed = time.monotonic() - start
     if result.returncode != 0:
         raise RuntimeError(
             f"claude -p exited {result.returncode}\nstderr: {result.stderr}"
         )
+    print(f"[ClaudeCodeLM] Got response ({len(result.stdout)} chars) in {elapsed:.2f}s", file=sys.stderr)
     return result.stdout
 
 
@@ -144,11 +150,6 @@ class ClaudeCodeLM(BaseLM):
         messages: list[dict[str, Any]] | None = None,
         **kwargs: Any,
     ) -> SimpleNamespace:
-        import sys
-
         text_input = _serialize_messages(prompt, messages)
-        input_len = len(text_input)
-        print(f"[ClaudeCodeLM] Calling claude -p --model {self.cli_model} ({input_len} chars)...", file=sys.stderr)
         response_text = _call_claude(text_input, model=self.cli_model, timeout=self.timeout)
-        print(f"[ClaudeCodeLM] Got response ({len(response_text)} chars)", file=sys.stderr)
         return _make_response(response_text, self.model)


### PR DESCRIPTION
## Summary

Closes #5.

- Moved `[ClaudeCodeLM]` logging from `forward()` into `_call_claude()` so all callers benefit from timing
- Each `Got response` line now includes wall-clock elapsed time (`in X.XXs`)
- Makes it trivial to pinpoint which LLM call is the bottleneck during long hook runs

## What changed

`plumb/programs/claude_code_lm.py`:
- Added `time.monotonic()` timing around `subprocess.run` in `_call_claude()`
- Log lines now emitted from `_call_claude()` instead of `forward()`
- Removed duplicate logging from `forward()` (now just serializes and delegates)

Before:
```
[ClaudeCodeLM] Got response (325 chars)
```

After:
```
[ClaudeCodeLM] Got response (325 chars) in 4.93s
```

## Test plan

- [x] All 20 `test_claude_code_lm.py` tests pass
- [x] Full test suite: 421 passed, 4 pre-existing failures (unrelated background gate tests)
- [x] E2E validation: real commit → background hook → check `hook.log` for timing (see PR comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)